### PR TITLE
💄 add scroll to squads list in sidebar

### DIFF
--- a/packages/front/src/components/b-sidebar.vue
+++ b/packages/front/src/components/b-sidebar.vue
@@ -109,6 +109,12 @@ const toggleModal = () => { showModal.value = !showModal.value };
 .b-sidebar__squad-wrapper {
   display: grid;
   row-gap: var(--unit-0500);
+  overflow-y: scroll;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   .b-sidebar__squad {
     width: 100%;


### PR DESCRIPTION
Adds scrolling to the squad list in the left sidebar. Closes #114.

![scroll](https://user-images.githubusercontent.com/25932176/196831090-0d615dd0-6199-4520-8d2b-74543fd457e8.gif)
